### PR TITLE
usebeacon if user wants that

### DIFF
--- a/src/transport/http.js
+++ b/src/transport/http.js
@@ -7,6 +7,9 @@ export default function create(url, opts = {}) {
   opts.method = opts.method || 'POST';
   opts.formatter = opts.formatter || json;
   return function (entry) {
+    if (opts.useBeacon) {
+      return navigator.sendBeacon(url, opts.formatter(entry));
+    }
     const req = http.request(extend(parse(url), opts));
     req.end(opts.formatter(entry));
   };


### PR DESCRIPTION
let the user use `navigator.sendBeacon` api instead of xhr.

Unfortunately there's no browserify http module which supports sendBeacon. :(
